### PR TITLE
Updated getUserMedia for the new standard

### DIFF
--- a/static/scripts/app.js
+++ b/static/scripts/app.js
@@ -1,10 +1,31 @@
+//Check for nessesary Web API's first.
+
+if (window.MediaRecorder) {
+  console.log("MediaRecorder supported!");
+} else {
+  console.error(
+    "MediaRecorder not supported, if your in macOS Safari (MediaRecorder for macOS Safari is in beta), you can enable Develop menu, then enable MediaRecorder in Develop > Experimental Features > MediaRecorder"
+  );
+  console.log(
+    "Enable Develop Menu, https://support.apple.com/guide/safari/use-the-developer-tools-in-the-develop-menu-sfri20948/mac"
+  );
+}
+if (navigator.mediaDevices.getUserMedia) {
+  console.log("getUserMedia supported!");
+} else {
+  console.log(
+    "getUserMedia not supported on your browser! (IE has no support at all.)"
+  );
+  document.querySelector(".info-display").innerText =
+    "Your device does not support getUserMedia, a Web API nessesary for this to operate";
+}
 // set up basic variables for app
 
-var record = document.querySelector('.record');
-var stop = document.querySelector('.stop');
-var upload = document.querySelector('.upload');
-var soundClips = document.querySelector('.sound-clips');
-var canvas = document.querySelector('.visualizer');
+var record = document.querySelector(".record");
+var stop = document.querySelector(".stop");
+var upload = document.querySelector(".upload");
+var soundClips = document.querySelector(".sound-clips");
+var canvas = document.querySelector(".visualizer");
 var mediaRecorder = null;
 var mediaStreamSource = null;
 var ignoreAutoPlay = false;
@@ -20,106 +41,97 @@ var audioCtx = new (window.AudioContext || webkitAudioContext)();
 var canvasCtx = canvas.getContext("2d");
 
 //main block for doing the audio recording
+var constraints = { audio: true };
+var chunks = [];
 
-if (navigator.mediaDevices.getUserMedia) {
-  console.log('getUserMedia supported.');
+var onSuccess = function (stream) {
+  mediaRecorder = new MediaRecorder(stream);
+  mediaStreamSource = audioCtx.createMediaStreamSource(stream);
+  record.onclick = function () {
+    visualize(stream);
 
-  var constraints = { audio: true };
-  var chunks = [];
-
-  var onSuccess = function(stream) {
-    mediaRecorder = new MediaRecorder(stream);
-    mediaStreamSource = audioCtx.createMediaStreamSource(stream);
-    record.onclick = function() {
-      visualize(stream);
-
-      // Display a countdown before recording starts.
-      var progress = document.querySelector('.progress-display');
-      progress.innerText = "3";
-      document.querySelector('.info-display').innerText = "";
-      setTimeout(function() {
-	  progress.innerText = "2";
-	  setTimeout(function() {
-	      progress.innerText = "1";
-	      setTimeout(function() {
-		  progress.innerText = "";
-		  startRecording();
-	      }, 1000);
-	  }, 1000);
+    // Display a countdown before recording starts.
+    var progress = document.querySelector(".progress-display");
+    progress.innerText = "3";
+    document.querySelector(".info-display").innerText = "";
+    setTimeout(function () {
+      progress.innerText = "2";
+      setTimeout(function () {
+        progress.innerText = "1";
+        setTimeout(function () {
+          progress.innerText = "";
+          startRecording();
+        }, 1000);
       }, 1000);
-      stop.disabled = false;
-      record.disabled = true;
+    }, 1000);
+    stop.disabled = false;
+    record.disabled = true;
+  };
+
+  stop.onclick = function () {
+    if (mediaRecorder.state == "inactive") {
+      // The user has already pressed stop, so don't set up another word.
+      ignoreAutoPlay = true;
+    } else {
+      mediaRecorder.stop();
     }
+    mediaStreamSource.disconnect();
+    console.log(mediaRecorder.state);
+    record.style.background = "";
+    record.style.color = "";
+    stop.disabled = true;
+    record.disabled = false;
+  };
 
-    stop.onclick = function() {
-      if (mediaRecorder.state == 'inactive') {
-        // The user has already pressed stop, so don't set up another word.
-        ignoreAutoPlay = true;
-      } else {
-        mediaRecorder.stop();
-      }
-      mediaStreamSource.disconnect();
-      console.log(mediaRecorder.state);
-      record.style.background = "";
-      record.style.color = ""; 
-      stop.disabled = true;
-      record.disabled = false;
-    }
+  upload.onclick = function () {
+    saveRecordings();
+  };
 
-    upload.onclick = function() {
-      saveRecordings();
-    }
+  mediaRecorder.onstop = function (e) {
+    console.log("data available after MediaRecorder.stop() called.");
 
-    mediaRecorder.onstop = function(e) {
-      console.log("data available after MediaRecorder.stop() called.");
+    var clipName = document.querySelector(".info-display").innerText;
+    var clipContainer = document.createElement("article");
+    var clipLabel = document.createElement("p");
+    var audio = document.createElement("audio");
+    var deleteButton = document.createElement("button");
 
-      var clipName = document.querySelector('.info-display').innerText;
-      var clipContainer = document.createElement('article');
-      var clipLabel = document.createElement('p');
-      var audio = document.createElement('audio');
-      var deleteButton = document.createElement('button');
-     
-      clipContainer.classList.add('clip');
-      clipLabel.classList.add('clip-label');
-      audio.setAttribute('controls', '');
-      deleteButton.textContent = 'Delete';
-      deleteButton.className = 'delete';
-      clipLabel.textContent = clipName;
+    clipContainer.classList.add("clip");
+    clipLabel.classList.add("clip-label");
+    audio.setAttribute("controls", "");
+    deleteButton.textContent = "Delete";
+    deleteButton.className = "delete";
+    clipLabel.textContent = clipName;
 
-      clipContainer.appendChild(audio);
-      clipContainer.appendChild(clipLabel);
-      clipContainer.appendChild(deleteButton);
-      soundClips.appendChild(clipContainer);
+    clipContainer.appendChild(audio);
+    clipContainer.appendChild(clipLabel);
+    clipContainer.appendChild(deleteButton);
+    soundClips.appendChild(clipContainer);
 
-      audio.controls = true;
-      var blob = new Blob(chunks, { 'type' : 'audio/ogg; codecs=opus' });
-      chunks = [];
-      var audioURL = window.URL.createObjectURL(blob);
-      audio.src = audioURL;
-      console.log("recorder stopped");
+    audio.controls = true;
+    var blob = new Blob(chunks, { type: "audio/ogg; codecs=opus" });
+    chunks = [];
+    var audioURL = window.URL.createObjectURL(blob);
+    audio.src = audioURL;
+    console.log("recorder stopped");
 
-      deleteButton.onclick = function(e) {
-        evtTgt = e.target;
-        evtTgt.parentNode.parentNode.removeChild(evtTgt.parentNode);
-	updateProgress();
-      }
-    }
+    deleteButton.onclick = function (e) {
+      evtTgt = e.target;
+      evtTgt.parentNode.parentNode.removeChild(evtTgt.parentNode);
+      updateProgress();
+    };
+  };
 
-    mediaRecorder.ondataavailable = function(e) {
-      chunks.push(e.data);
-    }
-  }
+  mediaRecorder.ondataavailable = function (e) {
+    chunks.push(e.data);
+  };
+};
 
-  var onError = function(err) {
-    console.log('The following error occured: ' + err);
-  }
+var onError = function (err) {
+  console.log("The following error occured: " + err);
+};
 
-  navigator.mediaDevices.getUserMedia(constraints, onSuccess, onError);
-} else {
-  console.log('getUserMedia not supported on your browser! (IE has no support at all.)');
-  document.querySelector('.info-display').innerText = 
-	'Your device does not support the HTML5 API needed to record audio (this is a known problem on iOS)';  
-}
+navigator.mediaDevices.getUserMedia(constraints, onSuccess, onError);
 
 function visualize(stream) {
   var analyser = audioCtx.createAnalyser();
@@ -128,35 +140,33 @@ function visualize(stream) {
   var dataArray = new Uint8Array(bufferLength);
 
   mediaStreamSource.connect(analyser);
-  
-  WIDTH = canvas.width
+
+  WIDTH = canvas.width;
   HEIGHT = canvas.height;
 
-  draw()
+  draw();
 
   function draw() {
-
     requestAnimationFrame(draw);
 
     analyser.getByteTimeDomainData(dataArray);
 
-    canvasCtx.fillStyle = 'rgb(200, 200, 200)';
+    canvasCtx.fillStyle = "rgb(200, 200, 200)";
     canvasCtx.fillRect(0, 0, WIDTH, HEIGHT);
 
     canvasCtx.lineWidth = 2;
-    canvasCtx.strokeStyle = 'rgb(0, 0, 0)';
+    canvasCtx.strokeStyle = "rgb(0, 0, 0)";
 
     canvasCtx.beginPath();
 
-    var sliceWidth = WIDTH * 1.0 / bufferLength;
+    var sliceWidth = (WIDTH * 1.0) / bufferLength;
     var x = 0;
 
-    for(var i = 0; i < bufferLength; i++) {
- 
+    for (var i = 0; i < bufferLength; i++) {
       var v = dataArray[i] / 128.0;
-      var y = v * HEIGHT/2;
+      var y = (v * HEIGHT) / 2;
 
-      if(i === 0) {
+      if (i === 0) {
         canvasCtx.moveTo(x, y);
       } else {
         canvasCtx.lineTo(x, y);
@@ -165,66 +175,66 @@ function visualize(stream) {
       x += sliceWidth;
     }
 
-    canvasCtx.lineTo(canvas.width, canvas.height/2);
+    canvasCtx.lineTo(canvas.width, canvas.height / 2);
     canvasCtx.stroke();
   }
 }
 
 var wantedWords = [
-  'Zero',
-  'One',
-  'Two',
-  'Three',
-  'Four',
-  'Five',
-  'Six',
-  'Seven',
-  'Eight',
-  'Nine',
-  'On',
-  'Off',
-  'Stop',
-  'Go',
-  'Up',
-  'Down',
-  'Left',
-  'Right',
-  'Yes',
-  'No',
+  "Zero",
+  "One",
+  "Two",
+  "Three",
+  "Four",
+  "Five",
+  "Six",
+  "Seven",
+  "Eight",
+  "Nine",
+  "On",
+  "Off",
+  "Stop",
+  "Go",
+  "Up",
+  "Down",
+  "Left",
+  "Right",
+  "Yes",
+  "No",
 ];
 
 var fillerWords = [
-  'Dog',
-  'Cat',
-  'Bird',
-  'Tree',
-  'Marvin',
-  'Sheila',
-  'House',
-  'Bed',
-  'Wow',
-  'Happy',
+  "Dog",
+  "Cat",
+  "Bird",
+  "Tree",
+  "Marvin",
+  "Sheila",
+  "House",
+  "Bed",
+  "Wow",
+  "Happy",
 ];
 
 function getRecordedWords() {
-  var wordElements = document.querySelectorAll('.clip-label');
+  var wordElements = document.querySelectorAll(".clip-label");
   var wordCounts = {};
-  wordElements.forEach(function(wordElement) {
-      var word = wordElement.innerText;
-      if (!wordCounts.hasOwnProperty(word)) {
-	  wordCounts[word] = 0;
-      }
-      wordCounts[word] += 1;
+  wordElements.forEach(function (wordElement) {
+    var word = wordElement.innerText;
+    if (!wordCounts.hasOwnProperty(word)) {
+      wordCounts[word] = 0;
+    }
+    wordCounts[word] += 1;
   });
   return wordCounts;
 }
 
 function getAllWantedWords() {
   var wordCounts = {};
-  wantedWords.forEach(function(word) {
+  wantedWords.forEach(function (word) {
     wordCounts[word] = 5;
   });
-  fillerWords.forEach(function(word) {
+  fillerWords.forEach(function (word) {
     wordCounts[word] = 1;
   });
   return wordCounts;
@@ -282,12 +292,12 @@ function getNextWord() {
 function getProgressDescription() {
   var allWords = unrollWordCounts(getAllWantedWords());
   var remainingWords = unrollWordCounts(getRemainingWords());
-  return ((allWords.length + 1) - remainingWords.length) + "/" + allWords.length;
+  return allWords.length + 1 - remainingWords.length + "/" + allWords.length;
 }
 
 function updateProgress() {
   var progress = getProgressDescription();
-  document.querySelector('.progress-display').innerText = progress;
+  document.querySelector(".progress-display").innerText = progress;
 }
 
 function startRecording() {
@@ -301,7 +311,7 @@ function startRecording() {
     return;
   }
   updateProgress();
-  document.querySelector('.info-display').innerText = word;
+  document.querySelector(".info-display").innerText = word;
   mediaRecorder.start();
   console.log(mediaRecorder.state);
   console.log("recorder started");
@@ -310,7 +320,7 @@ function startRecording() {
 }
 
 function endRecording() {
-  if (mediaRecorder.state == 'inactive') {
+  if (mediaRecorder.state == "inactive") {
     // The user has already pressed stop, so don't set up another word.
     return;
   }
@@ -323,8 +333,12 @@ function endRecording() {
 }
 
 function promptToSave() {
-  if (confirm('Are you ready to upload your words?\nIf not, press cancel now,' + 
-	      ' and then press Upload once you are ready.')) {
+  if (
+    confirm(
+      "Are you ready to upload your words?\nIf not, press cancel now," +
+        " and then press Upload once you are ready."
+    )
+  ) {
     saveRecordings();
   }
   upload.disabled = false;
@@ -335,41 +349,44 @@ var clipIndex;
 
 function saveRecordings() {
   mediaStreamSource.disconnect();
-  allClips = document.querySelectorAll('.clip');
+  allClips = document.querySelectorAll(".clip");
   clipIndex = 0;
   uploadNextClip();
 }
 
 function uploadNextClip() {
-  document.querySelector('.progress-display').innerText = 'Uploading clip ' + 
-	clipIndex + '/' + unrollWordCounts(getAllWantedWords()).length;
+  document.querySelector(".progress-display").innerText =
+    "Uploading clip " +
+    clipIndex +
+    "/" +
+    unrollWordCounts(getAllWantedWords()).length;
   var clip = allClips[clipIndex];
-  clip.style.display = 'None';
-  var audioBlobUrl = clip.querySelector('audio').src;
-  var word = clip.querySelector('p').innerText;
+  clip.style.display = "None";
+  var audioBlobUrl = clip.querySelector("audio").src;
+  var word = clip.querySelector("p").innerText;
   var xhr = new XMLHttpRequest();
-  xhr.open('GET', audioBlobUrl, true);
-  xhr.responseType = 'blob';
-  xhr.onload = function(e) {
+  xhr.open("GET", audioBlobUrl, true);
+  xhr.responseType = "blob";
+  xhr.onload = function (e) {
     if (this.status == 200) {
       var blob = this.response;
       var ajaxRequest = new XMLHttpRequest();
-      var uploadUrl = '/upload?word=' + word + '&_csrf_token=' + csrf_token;
-      ajaxRequest.open('POST', uploadUrl, true);
-      ajaxRequest.setRequestHeader('Content-Type', 'application/json');    
-      ajaxRequest.onreadystatechange = function() {
+      var uploadUrl = "/upload?word=" + word + "&_csrf_token=" + csrf_token;
+      ajaxRequest.open("POST", uploadUrl, true);
+      ajaxRequest.setRequestHeader("Content-Type", "application/json");
+      ajaxRequest.onreadystatechange = function () {
         if (ajaxRequest.readyState == 4) {
-	  if (ajaxRequest.status === 200) {
+          if (ajaxRequest.status === 200) {
             clipIndex += 1;
             if (clipIndex < allClips.length) {
-	      uploadNextClip();
-	    } else {
-	      allDone();
-	    }
+              uploadNextClip();
+            } else {
+              allDone();
+            }
           } else {
-            alert('Uploading failed with error code ' + ajaxRequest.status);
+            alert("Uploading failed with error code " + ajaxRequest.status);
           }
-	}
+        }
       };
       ajaxRequest.send(blob);
     }
@@ -378,6 +395,6 @@ function uploadNextClip() {
 }
 
 function allDone() {
-  document.cookie = 'all_done=true; path=/';
+  document.cookie = "all_done=true; path=/";
   location.reload(true);
 }

--- a/static/scripts/app.js
+++ b/static/scripts/app.js
@@ -1,11 +1,3 @@
-// fork getUserMedia for multiple browser versions, for the future
-// when more browsers support MediaRecorder
-
-navigator.getUserMedia = ( navigator.getUserMedia ||
-                       navigator.webkitGetUserMedia ||
-                       navigator.mozGetUserMedia ||
-                       navigator.msGetUserMedia);
-
 // set up basic variables for app
 
 var record = document.querySelector('.record');
@@ -29,7 +21,7 @@ var canvasCtx = canvas.getContext("2d");
 
 //main block for doing the audio recording
 
-if (navigator.getUserMedia) {
+if (navigator.mediaDevices.getUserMedia) {
   console.log('getUserMedia supported.');
 
   var constraints = { audio: true };
@@ -122,9 +114,9 @@ if (navigator.getUserMedia) {
     console.log('The following error occured: ' + err);
   }
 
-  navigator.getUserMedia(constraints, onSuccess, onError);
+  navigator.mediaDevices.getUserMedia(constraints, onSuccess, onError);
 } else {
-  console.log('getUserMedia not supported on your browser!');
+  console.log('getUserMedia not supported on your browser! (IE has no support at all.)');
   document.querySelector('.info-display').innerText = 
 	'Your device does not support the HTML5 API needed to record audio (this is a known problem on iOS)';  
 }


### PR DESCRIPTION
Removed beginning code as it is deprecated. https://developer.mozilla.org/en-US/docs/Web/API/Navigator/getUserMedia
"This is a legacy method. Please use the newer navigator.mediaDevices.getUserMedia() instead. While technically not deprecated, this old callback version is marked as such, since the specification strongly encourages using the newer promise returning version."

Updated getUserMedia with Mozilla's Web API docs, https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia
navigator.getUserMedia doesn't work in Safari, as it has changed to navigator.mediaDevices.getUserMedia

Added to the console message about no support for IE. https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia#Browser_compatibility